### PR TITLE
support aliyunmanagedcontrolplane custom apiserver access and fix pan…

### DIFF
--- a/api/cs/v1alpha1/related_types.go
+++ b/api/cs/v1alpha1/related_types.go
@@ -33,16 +33,31 @@ type ManagedKubernetesStatusConnection struct {
 }
 
 func (c *ManagedKubernetesStatusConnection) Decode(src map[string]*string) (err error) {
-	c.APIServerInternet = *src["api_server_internet"]
-	c.APIServerIntranet = *src["api_server_intranet"]
-	c.MasterPublicIP = *src["master_public_ip"]
-	c.ServiceDomain = *src["service_domain"]
+	if src == nil {
+		return fmt.Errorf("empty block ManagedKubernetesStatusConnection")
+	}
+	if _, ok := src["api_server_internet"]; ok {
+		c.APIServerInternet = *src["api_server_internet"]
+	}
+	if _, ok := src["api_server_intranet"]; ok {
+		c.APIServerIntranet = *src["api_server_intranet"]
+	}
+	if _, ok := src["master_public_ip"]; ok {
+		c.MasterPublicIP = *src["master_public_ip"]
+	}
+	if _, ok := src["service_domain"]; ok {
+		c.ServiceDomain = *src["service_domain"]
+	}
+	apiServer := c.APIServerInternet
 
 	if c.APIServerInternet == "" {
-		return fmt.Errorf("empty field api_server_internet")
+		if c.APIServerIntranet == "" {
+			return fmt.Errorf("empty field api_server_internet and api_server_intranet")
+		}
+		apiServer = c.APIServerIntranet
 	}
 
-	endpointInfo, err := url.Parse(c.APIServerInternet)
+	endpointInfo, err := url.Parse(apiServer)
 	if err != nil {
 		return fmt.Errorf("failed to parse api_server_internet: %+v", src)
 	}
@@ -75,9 +90,15 @@ func (c *CertificateAuthority) Decode(src map[string]*string) (err error) {
 	if src == nil {
 		return fmt.Errorf("empty block CertificateAuthority")
 	}
-	c.ClusterCertStr = *src["cluster_cert"]
-	c.ClientCertStr = *src["client_cert"]
-	c.ClientKeyStr = *src["client_key"]
+	if _, ok := src["cluster_cert"]; ok {
+		c.ClusterCertStr = *src["cluster_cert"]
+	}
+	if _, ok := src["client_cert"]; ok {
+		c.ClientCertStr = *src["client_cert"]
+	}
+	if _, ok := src["client_key"]; ok {
+		c.ClientKeyStr = *src["client_key"]
+	}
 	if c.ClusterCertStr == "" {
 		return fmt.Errorf("empty field cluster_cert")
 	}

--- a/internal/controller/controlplane/aliyunmanagedcontrolplane_controller.go
+++ b/internal/controller/controlplane/aliyunmanagedcontrolplane_controller.go
@@ -305,8 +305,7 @@ func (r *AliyunManagedControlPlaneReconciler) reconcileManagedKubernetes(
 					ResourceGroupID:    &aliyunControlPlane.Spec.ResourceGroup,
 					DeletionProtection: &aliyunControlPlane.Spec.DeletionProtection,
 
-					// todo:
-					// Public: aliyunControlPlane.Spec.Network.EndpointAccess.Public,
+					SlbInternetEnabled: &aliyunControlPlane.Spec.EndpointAccess.Public,
 				},
 			},
 		}


### PR DESCRIPTION
1. support aliyunmanagedcontrolplane custom apiserver access
2. When aliyunControlPlane.Spec.EndpointAccess.Public is false and passed to ManagedKubernetes, ManagedKubernetesStatusConnection.APIServerInternet is nil, making it impossible to obtain the internal API server information
3. ManagedKubernetesStatusConnection.APIServerInternet is nil, accessing a nil pointer will cause a panic